### PR TITLE
update github flows and fix one warning with double reference

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,19 +6,26 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install clippy
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - name: clippy check
+        uses: giraffate/clippy-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Run fmt check
-        run: cargo fmt --all -- --check
+      - uses: actions/checkout@v4
+      - name: Install rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: fmt check
+        uses: mbrobbel/rustfmt-check@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,6 @@ jobs:
           xd009642/tarpaulin:latest \
           cargo tarpaulin -f -t 5 --out Xml -v -- --test-threads=1 || true
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
-        token: ${{secrets.CODECOV_TOKEN}}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release-crates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: publish package to crates
         run: |
           cargo package
@@ -18,7 +18,7 @@ jobs:
   release-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: static build release
         run: |
           docker run --rm -t \
@@ -38,17 +38,14 @@ jobs:
   release-osx:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: build release
         run: cargo build --release --verbose
       - name: archive
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-x86_64-osx.tar.gz aws-mfa-session
       - name: publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: aws-mfa-session-x86_64-osx.tar.gz
         env:
@@ -64,7 +61,7 @@ jobs:
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-x86_64-windows.tar.gz aws-mfa-session.exe
         shell: bash
       - name: publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: aws-mfa-session-x86_64-windows.tar.gz
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,15 +14,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-        if: matrix.os == 'macOS-latest'
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: build
         run: cargo build --verbose
       - name: test
         run: cargo test --no-fail-fast --verbose --all -- --nocapture
         env:
           RUST_BACKTRACE: 1
+          RUST_LOG: trace

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub async fn run(opts: Args) -> Result<(), CliError> {
 
             let mfa_devices = response.mfa_devices();
             let serial = &mfa_devices.first().ok_or(CliError::NoMFA)?.serial_number();
-            serial.clone().to_owned()
+            (*serial).to_owned()
         }
         Some(other) => other,
     };


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to use newer, more stable versions and fixes a double reference warning in the MFA device serial extraction.  
- Fix the double reference warning in src/lib.rs by replacing serial.clone().to_owned() with (*serial).to_owned().  
- Upgrade various GitHub Actions in the workflows (checkout, toolchain, codecov, clippy, and release actions) to newer versions.  
- Introduce an updated configuration for clippy and rustfmt checks in the CI pipeline.