### PR TITLE
add new release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,50 @@ jobs:
           sudo strip target/x86_64-unknown-linux-musl/release/aws-mfa-session
           sudo tar -C target/x86_64-unknown-linux-musl/release -czf  $(pwd)/aws-mfa-session-x86_64-linux.tar.gz aws-mfa-session
       - name: publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: aws-mfa-session-x86_64-linux.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  release-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: static build release
+        run: |
+          docker run --rm -t \
+            -v "$(pwd)":/volume \
+            clux/muslrust cargo build --release
+      - name: archive
+        run: |
+          sudo strip target/aarch64-unknown-linux-musl/release/aws-mfa-session
+          sudo tar -C target/aarch64-unknown-linux-musl/release -czf  $(pwd)/aws-mfa-session-aarch64-linux.tar.gz aws-mfa-session
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: aws-mfa-session-aarch64-linux.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release-osx:
     runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build release
+        run: cargo build --release --verbose
+      - name: archive
+        run: tar -C target/release -czf $(pwd)/aws-mfa-session-aarch64-osx.tar.gz aws-mfa-session
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: aws-mfa-session-aarch64-osx.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-osx-x86_64:
+    runs-on: macOS-13
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -64,5 +100,21 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: aws-mfa-session-x86_64-windows.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-windows-arm:
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v2
+      - name: build release
+        run: cargo build --release --verbose
+      - name: archive
+        run: tar -C target/release -czf $(pwd)/aws-mfa-session-aarch64-windows.tar.gz aws-mfa-session.exe
+        shell: bash
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: aws-mfa-session-aarch64-windows.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds new release targets for ARM Linux, macOS (arm64 and x86_64), and Windows ARM, and upgrades the GitHub release action to v2  
- Bump `softprops/action-gh-release` from v1 to v2  
- Introduce `release-linux-arm`, `release-osx`, `release-osx-x86_64`, and `release-windows-arm` jobs