### PR TITLE
add duration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Generate session credentials with defined profile and non-default credential fil
 aws-mfa-session --credentials-file ~/.aws/credentials2 --profile dev --update-profile mfa-session --code 123456
 ```
 
+Generate session credentials with custom duration (2 hours):
+
+```sh
+aws-mfa-session --code 123456 --duration 7200 -e
+```
+
+Generate session credentials with maximum duration (36 hours):
+
+```sh
+aws-mfa-session --code 123456 --duration 129600 -e
+```
+
 ## Installation
 
 ### Pre-built Binaries
@@ -106,17 +118,27 @@ cargo install --path .
 ## Usage
 
 ```
-aws-mfa-session [OPTIONS] --code <CODE>
+Usage: aws-mfa-session [OPTIONS] --code <CODE>
 
 Options:
-  -c, --code <CODE>                    MFA code from MFA resource
-  -p, --profile <PROFILE>              AWS credential profile to use
-  -f, --credentials-file <FILE>        AWS credentials file location
-  -r, --region <REGION>                AWS region
-  -a, --arn <ARN>                      MFA device ARN from user profile
-  -s                                   Run shell with AWS credentials as environment variables
-  -e                                   Print(export) AWS credentials as environment variables
-  -u, --update-profile <PROFILE>       Update AWS credential profile with temporary session credentials
-  -h, --help                           Print help
-  -V, --version                        Print version
+  -p, --profile <PROFILE>
+          AWS credential profile to use. AWS_PROFILE is used by default
+  -f, --credentials-file <FILE>
+          AWS credentials file location to use. AWS_SHARED_CREDENTIALS_FILE is used if not defined
+  -r, --region <REGION>
+          AWS region. AWS_REGION is used if not defined
+  -c, --code <CODE>
+          MFA code from MFA resource
+  -a, --arn <ARN>
+          MFA device ARN from user profile. It could be detected automatically
+  -d, --duration <DURATION>
+          Session duration in seconds (900-129600) [default: 3600]
+  -s
+          Run shell with AWS credentials as environment variables
+  -e
+          Print(export) AWS credentials as environment variables
+  -u, --update-profile <SESSION_PROFILE>
+          Update AWS credential profile with temporary session credentials
+  -h, --help
+          Print help
 ```

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -69,7 +69,7 @@ fn credential_file() -> io::Result<PathBuf> {
         Ok(s) => PathBuf::from(s),
         _ => {
             let mut file = home_dir().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::Other, "Cannot find home directory")
+                io::Error::other("Cannot find home directory")
             })?;
             file.push(".aws");
             file.push("credentials");

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -68,9 +68,8 @@ fn credential_file() -> io::Result<PathBuf> {
     let file = match std::env::var(AWS_SHARED_CREDENTIALS_FILE) {
         Ok(s) => PathBuf::from(s),
         _ => {
-            let mut file = home_dir().ok_or_else(|| {
-                io::Error::other("Cannot find home directory")
-            })?;
+            let mut file =
+                home_dir().ok_or_else(|| io::Error::other("Cannot find home directory"))?;
             file.push(".aws");
             file.push("credentials");
             file

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use aws_sdk_sts::operation::{
 
 #[derive(Debug)]
 pub enum CliError {
+    ValidationError(String),
     NoMFA,
     NoCredentials,
     NoAccount,
@@ -20,6 +21,7 @@ pub enum CliError {
 impl std::fmt::Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            CliError::ValidationError(e) => write!(f, "Validation error: {}", e),
             CliError::NoMFA => write!(f, "No MFA device in user profile"),
             CliError::NoCredentials => write!(f, "No returned credentials"),
             CliError::NoAccount => write!(f, "No returned account"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ const DEFAULT_SHELL: &str = "cmd.exe";
 
 const AWS_PROFILE: &str = "AWS_PROFILE";
 const AWS_DEFAULT_REGION: &str = "AWS_DEFAULT_REGION";
+const MIN_SESSION_DURATION: i32 = 900; // 15 minutes
+const MAX_SESSION_DURATION: i32 = 129600; // 36 hours
 
 fn region(s: &str) -> Result<Region, CliError> {
     Ok(Region::new(s.to_owned()))
@@ -71,11 +73,11 @@ pub async fn run(opts: Args) -> Result<(), CliError> {
         ));
     }
 
-    if opts.duration < 900 || opts.duration > 129600 {
-        return Err(CliError::ValidationError(
-            "Session duration must be between 900 and 129600 seconds (15 minutes to 36 hours)"
-                .to_string(),
-        ));
+    if opts.duration < MIN_SESSION_DURATION || opts.duration > MAX_SESSION_DURATION {
+        return Err(CliError::ValidationError(format!(
+            "Session duration must be between {} and {} seconds (15 minutes to 36 hours)",
+            MIN_SESSION_DURATION, MAX_SESSION_DURATION
+        )));
     }
 
     // ProfileProvider is limited, but AWS_PROFILE is used elsewhere

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,12 @@ pub struct Args {
 }
 
 pub async fn run(opts: Args) -> Result<(), CliError> {
+    if !opts.code.chars().all(char::is_numeric) || opts.code.len() != 6 {
+        return Err(CliError::SdkError(
+            "MFA code must be exactly 6 digits".to_string(),
+        ));
+    }
+
     // ProfileProvider is limited, but AWS_PROFILE is used elsewhere
     if let Some(profile) = opts.profile {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,13 @@ pub struct Args {
 
 pub async fn run(opts: Args) -> Result<(), CliError> {
     if !opts.code.chars().all(char::is_numeric) || opts.code.len() != 6 {
-        return Err(CliError::SdkError(
+        return Err(CliError::ValidationError(
             "MFA code must be exactly 6 digits".to_string(),
         ));
     }
 
     if opts.duration < 900 || opts.duration > 129600 {
-        return Err(CliError::SdkError(
+        return Err(CliError::ValidationError(
             "Session duration must be between 900 and 129600 seconds (15 minutes to 36 hours)"
                 .to_string(),
         ));


### PR DESCRIPTION
This PR adds duration configuration for session token and validation for mfa code

- Add `--duration` CLI argument with default and range checks, and wire it into the AWS session token request.
- Validate that the MFA code is exactly 6 numeric digits.
- Update README with examples and detailed usage for the new `--duration` flag.