### PR TITLE
fix(credentials): robust INI editing, enforce 0600, create missing file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,6 @@ dependencies = [
  "dialoguer",
  "dirs",
  "miette",
- "regex",
  "rust-ini",
  "serial_test",
  "tempfile",
@@ -1930,18 +1929,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT"
 [dependencies]
 dirs = "6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-regex = "1"
 aws-types = "1"
 aws-config = "1"
 aws-sdk-iam = "1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A command line utility to generate temporary AWS credentials using virtual MFA d
 * **Automatic MFA device selection** - reads `mfa_serial` from AWS profile configuration (~/.aws/config or ~/.aws/credentials), with fallback to automatic device detection
 * Generate temporary credentials using AWS STS
 * **Enhanced error reporting** with detailed error messages
-* **Atomic credentials file updates** - prevents file corruption during concurrent access
+* **Atomic credentials file updates** - the file is replaced via an atomic rename, preventing partial/torn writes
 * Multiple output options:
   * Export as environment variables
   * Launch new shell with credentials
@@ -354,8 +354,8 @@ Options:
 
 * **Input validation**: MFA codes must be exactly 6 digits
 * **Duration validation**: Session duration is validated to be within AWS limits (15 minutes to 36 hours)
-* **Atomic file operations**: Credentials file updates are atomic to prevent corruption
-* **Permission preservation**: Original file permissions are maintained when updating credentials
+* **Atomic file operations**: Credentials file updates use an atomic rename to prevent partial/torn writes
+* **Restrictive permissions**: On Unix, the credentials file is written with `0600` permissions (owner read/write only)
 * **Shell injection protection**: All shell output is properly escaped for security
 * **Multi-shell support**: Supports Bash, Zsh, Fish, Sh, CMD, and PowerShell with proper prompt setting
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -46,10 +46,10 @@ impl Profile {
 /// target section. Everything else — comments, ordering, spacing of other
 /// sections — is preserved byte-for-byte.
 ///
-/// Section detection is line-based: a header is a line whose trimmed text starts
-/// with `[`, and the target section is the header line whose trimmed text equals
-/// `[name]` exactly. This avoids the substring/prefix and `$`-expansion hazards
-/// of the previous regex-replacement approach.
+/// Section detection is line-based: a header is any line whose left-trimmed text
+/// starts with `[`, and the target section is the header line whose fully-trimmed
+/// text equals `[name]` exactly. This avoids the substring/prefix and
+/// `$`-expansion hazards of the previous regex-replacement approach.
 pub fn update_profile(config: &str, profile: &Profile) -> String {
     let target = profile.config_section_header(); // "[name]"
     let new_section = profile.config_section(); // ends with a single '\n'
@@ -62,22 +62,23 @@ pub fn update_profile(config: &str, profile: &Profile) -> String {
     match lines.iter().position(|l| l.trim() == target) {
         Some(start) => {
             // Span runs to the next section header (or EOF)...
-            let mut end = lines.len();
-            for (i, l) in lines.iter().enumerate().skip(start + 1) {
-                if is_header(l) {
-                    end = i;
-                    break;
-                }
-            }
+            let mut end = lines[start + 1..]
+                .iter()
+                .position(|l| is_header(l))
+                .map_or(lines.len(), |i| start + 1 + i);
             // ...but trailing blank lines act as separators and stay put.
             while end - 1 > start && lines[end - 1].trim().is_empty() {
                 end -= 1;
             }
 
             let mut out = String::with_capacity(config.len() + new_section.len());
-            lines[..start].iter().for_each(|l| out.push_str(l));
+            for line in &lines[..start] {
+                out.push_str(line);
+            }
             out.push_str(&new_section);
-            lines[end..].iter().for_each(|l| out.push_str(l));
+            for line in &lines[end..] {
+                out.push_str(line);
+            }
             out
         }
         None if config.is_empty() => new_section,
@@ -116,6 +117,18 @@ fn credential_file() -> io::Result<PathBuf> {
     Ok(file)
 }
 
+/// Set the Unix permission bits of `path`. No-op on non-Unix platforms.
+#[cfg(unix)]
+fn set_mode(path: &std::path::Path, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn set_mode(_path: &std::path::Path, _mode: u32) -> io::Result<()> {
+    Ok(())
+}
+
 pub fn update_credentials(profile: &Profile) -> io::Result<()> {
     let file_path = credential_file()?;
 
@@ -137,12 +150,10 @@ pub fn update_credentials(profile: &Profile) -> io::Result<()> {
         .unwrap_or_else(|| std::path::Path::new("."));
     if !temp_dir.as_os_str().is_empty() && !temp_dir.exists() {
         fs::create_dir_all(temp_dir)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            // We just created ~/.aws; it should not be group/other accessible.
-            let _ = fs::set_permissions(temp_dir, fs::Permissions::from_mode(0o700));
-        }
+        // We just created ~/.aws; tighten it to owner-only. Best-effort: the
+        // credentials file itself is forced to 0600 below regardless, so a
+        // failure to chmod the directory must not abort the credential write.
+        let _ = set_mode(temp_dir, 0o700);
     }
 
     let temp_file = NamedTempFile::new_in(temp_dir)?;
@@ -150,11 +161,8 @@ pub fn update_credentials(profile: &Profile) -> io::Result<()> {
 
     // Enforce 0600 on the secret-bearing file rather than inheriting whatever
     // permissions the original had (which may have been group/world readable).
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(temp_file.path(), fs::Permissions::from_mode(0o600))?;
-    }
+    // This is the critical protection, so its failure is propagated.
+    set_mode(temp_file.path(), 0o600)?;
 
     temp_file.persist(&file_path)?;
 
@@ -175,6 +183,17 @@ mod test {
             region: Some("us-east-1".to_string()),
         }
     }
+
+    /// Assert the low 9 permission bits of `path`. No-op on non-Unix platforms.
+    #[cfg(unix)]
+    fn assert_mode(path: &std::path::Path, expected: u32, msg: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, expected, "{msg}");
+    }
+
+    #[cfg(not(unix))]
+    fn assert_mode(_path: &std::path::Path, _expected: u32, _msg: &str) {}
 
     #[test]
     fn test_update_profile_empty() {
@@ -679,16 +698,7 @@ aws_secret_access_key = DEFAULTSECRET
         assert!(written.contains("[session]"));
         assert!(written.contains("aws_access_key_id = AKIATEST"));
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
-            assert_eq!(
-                mode & 0o777,
-                0o600,
-                "newly created credentials file must be 0600"
-            );
-        }
+        assert_mode(&path, 0o600, "newly created credentials file must be 0600");
     }
 
     #[test]
@@ -697,12 +707,7 @@ aws_secret_access_key = DEFAULTSECRET
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("credentials");
         std::fs::write(&path, "[existing]\naws_access_key_id = OLD\n").unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
-        }
+        set_mode(&path, 0o644).unwrap();
 
         unsafe { std::env::set_var(AWS_SHARED_CREDENTIALS_FILE, &path) };
         let result = update_credentials(&sample_profile("session"));
@@ -713,16 +718,11 @@ aws_secret_access_key = DEFAULTSECRET
         assert!(written.contains("[existing]")); // pre-existing content preserved
         assert!(written.contains("[session]")); // new profile appended
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
-            assert_eq!(
-                mode & 0o777,
-                0o600,
-                "loose 0644 permissions must be tightened to 0600"
-            );
-        }
+        assert_mode(
+            &path,
+            0o600,
+            "loose 0644 permissions must be tightened to 0600",
+        );
     }
 
     #[test]
@@ -730,11 +730,7 @@ aws_secret_access_key = DEFAULTSECRET
     fn test_update_credentials_does_not_repermission_existing_dir() {
         let dir = tempfile::tempdir().unwrap();
         // The parent directory already exists with perms the tool must not change.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
+        set_mode(dir.path(), 0o755).unwrap();
         let path = dir.path().join("credentials");
 
         unsafe { std::env::set_var(AWS_SHARED_CREDENTIALS_FILE, &path) };
@@ -742,18 +738,15 @@ aws_secret_access_key = DEFAULTSECRET
         unsafe { std::env::remove_var(AWS_SHARED_CREDENTIALS_FILE) };
         result.unwrap();
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let dir_mode = std::fs::metadata(dir.path()).unwrap().permissions().mode();
-            assert_eq!(
-                dir_mode & 0o777,
-                0o755,
-                "a pre-existing parent directory must be left untouched"
-            );
-            // The credentials file itself is still written 0600.
-            let file_mode = std::fs::metadata(&path).unwrap().permissions().mode();
-            assert_eq!(file_mode & 0o777, 0o600);
-        }
+        assert_mode(
+            dir.path(),
+            0o755,
+            "a pre-existing parent directory must be left untouched",
+        );
+        assert_mode(
+            &path,
+            0o600,
+            "the credentials file itself is still written 0600",
+        );
     }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,5 +1,4 @@
 use dirs::home_dir;
-use regex::{Regex, escape};
 use std::path::PathBuf;
 use std::{fs, io};
 use tempfile::NamedTempFile;
@@ -43,19 +42,57 @@ impl Profile {
     }
 }
 
+/// Insert or replace `profile`'s section in an INI `config`, touching only the
+/// target section. Everything else — comments, ordering, spacing of other
+/// sections — is preserved byte-for-byte.
+///
+/// Section detection is line-based: a header is a line whose trimmed text starts
+/// with `[`, and the target section is the header line whose trimmed text equals
+/// `[name]` exactly. This avoids the substring/prefix and `$`-expansion hazards
+/// of the previous regex-replacement approach.
 pub fn update_profile(config: &str, profile: &Profile) -> String {
-    let header = profile.config_section_header();
-    let mut section = profile.config_section();
-    if config.contains(&header) {
-        section.push('\n');
+    let target = profile.config_section_header(); // "[name]"
+    let new_section = profile.config_section(); // ends with a single '\n'
 
-        // replace
-        let expr = format!("{}[^\\[]+", escape(&header));
-        let regex = Regex::new(&expr).unwrap();
-        regex.replace(config, section.as_str()).to_string()
-    } else {
-        // append
-        format!("{}\n\n{}", config, profile.config_section())
+    // Keep line endings attached so the untouched parts are rebuilt verbatim
+    // (also handles "\r\n" since trimming removes the trailing '\r').
+    let lines: Vec<&str> = config.split_inclusive('\n').collect();
+    let is_header = |l: &str| l.trim_start().starts_with('[');
+
+    match lines.iter().position(|l| l.trim() == target) {
+        Some(start) => {
+            // Span runs to the next section header (or EOF)...
+            let mut end = lines.len();
+            for (i, l) in lines.iter().enumerate().skip(start + 1) {
+                if is_header(l) {
+                    end = i;
+                    break;
+                }
+            }
+            // ...but trailing blank lines act as separators and stay put.
+            while end - 1 > start && lines[end - 1].trim().is_empty() {
+                end -= 1;
+            }
+
+            let mut out = String::with_capacity(config.len() + new_section.len());
+            lines[..start].iter().for_each(|l| out.push_str(l));
+            out.push_str(&new_section);
+            lines[end..].iter().for_each(|l| out.push_str(l));
+            out
+        }
+        None if config.is_empty() => new_section,
+        None => {
+            // Append after the existing content with exactly one blank-line separator.
+            let mut out = config.to_string();
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            if !out.ends_with("\n\n") {
+                out.push('\n');
+            }
+            out.push_str(&new_section);
+            out
+        }
     }
 }
 
@@ -81,19 +118,43 @@ fn credential_file() -> io::Result<PathBuf> {
 
 pub fn update_credentials(profile: &Profile) -> io::Result<()> {
     let file_path = credential_file()?;
-    let config = fs::read_to_string(&file_path)?;
+
+    // A missing credentials file is a valid starting point (e.g. env-var-only
+    // auth, fresh setup): treat it as empty and create it below.
+    let config = match fs::read_to_string(&file_path) {
+        Ok(config) => config,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e),
+    };
     let updated_config = update_profile(&config, profile);
 
-    let original_metadata = fs::metadata(&file_path)?;
-    let original_permissions = original_metadata.permissions();
-
+    // Ensure the parent directory exists so the temp file can be created next to
+    // the target (required for an atomic same-filesystem rename). Only adjust
+    // permissions on a directory we create ourselves — never re-permission a
+    // pre-existing directory the user owns.
     let temp_dir = file_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
-    let temp_file = NamedTempFile::new_in(temp_dir)?;
+    if !temp_dir.as_os_str().is_empty() && !temp_dir.exists() {
+        fs::create_dir_all(temp_dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            // We just created ~/.aws; it should not be group/other accessible.
+            let _ = fs::set_permissions(temp_dir, fs::Permissions::from_mode(0o700));
+        }
+    }
 
+    let temp_file = NamedTempFile::new_in(temp_dir)?;
     fs::write(temp_file.path(), updated_config)?;
-    fs::set_permissions(temp_file.path(), original_permissions)?;
+
+    // Enforce 0600 on the secret-bearing file rather than inheriting whatever
+    // permissions the original had (which may have been group/world readable).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(temp_file.path(), fs::Permissions::from_mode(0o600))?;
+    }
 
     temp_file.persist(&file_path)?;
 
@@ -103,6 +164,17 @@ pub fn update_credentials(profile: &Profile) -> io::Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serial_test::serial;
+
+    fn sample_profile(name: &str) -> Profile {
+        Profile {
+            name: name.to_string(),
+            access_key_id: "AKIATEST".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("token".to_string()),
+            region: Some("us-east-1".to_string()),
+        }
+    }
 
     #[test]
     fn test_update_profile_empty() {
@@ -113,12 +185,11 @@ mod test {
             session_token: None,
             region: None,
         };
+        // An empty config yields just the section (no leading blank lines).
         let updated = update_profile("", &profile);
         assert_eq!(
             updated,
-            r##"
-
-[session-production]
+            r##"[session-production]
 aws_access_key_id = AACCCCEESSSSKKEEYY
 aws_secret_access_key = SEC123RET
 "##
@@ -144,6 +215,7 @@ aws_access_key_id = AACCCCEESSSSKKEEYY/PROD
 aws_secret_access_key = SEC123RET/PROD
 "##;
 
+        // Appended after the existing content with a single blank-line separator.
         let updated = update_profile(original, &profile);
         assert_eq!(
             updated,
@@ -154,7 +226,6 @@ aws_secret_access_key = SEC123RET/DEFAULT
 [production]
 aws_access_key_id = AACCCCEESSSSKKEEYY/PROD
 aws_secret_access_key = SEC123RET/PROD
-
 
 [session-production]
 aws_access_key_id = AACCCCEESSSSKKEEYY
@@ -263,6 +334,7 @@ aws_secret_access_key = SEC123RET/PROD
 aws_access_key_id = AACCCCEESSSSKKEEYY/OLD
 aws_secret_access_key = SEC123RET/OLD"##;
 
+        // Replacing the last section leaves a single trailing newline (no extra blank line).
         let updated = update_profile(original, &profile);
         assert_eq!(
             updated,
@@ -277,7 +349,6 @@ aws_secret_access_key = SEC123RET/PROD
 [session-production]
 aws_access_key_id = AACCCCEESSSSKKEEYY/NEW
 aws_secret_access_key = SEC123RET/NEW
-
 "##
         );
     }
@@ -344,6 +415,7 @@ aws_secret_access_key = SEC123RET/PROD
 aws_access_key_id = AACCCCEESSSSKKEEYY/OLD
 aws_secret_access_key = SEC123RET/OLD"##;
 
+        // Idempotent, and the last-section replace keeps a single trailing newline.
         let updated_first = update_profile(original, &profile);
         let updated = update_profile(&updated_first, &profile);
         assert_eq!(
@@ -359,7 +431,6 @@ aws_secret_access_key = SEC123RET/PROD
 [session-production]
 aws_access_key_id = AACCCCEESSSSKKEEYY/NEW
 aws_secret_access_key = SEC123RET/NEW
-
 "##
         );
     }
@@ -433,6 +504,7 @@ aws_secret_access_key = SEC123RET/NEW
     }
 
     #[test]
+    #[serial]
     fn test_credential_file_default_path() {
         // Test that credential_file returns a path ending with .aws/credentials
         // when AWS_SHARED_CREDENTIALS_FILE is not set
@@ -463,5 +535,225 @@ aws_secret_access_key = SEC123RET/NEW
         };
 
         assert_eq!(profile.config_section_header(), "[test-profile]");
+    }
+
+    #[test]
+    fn test_update_profile_preserves_comments() {
+        let original = "\
+# top comment
+[default]
+aws_access_key_id = DEFAULTKEY
+; keep this comment between keys
+aws_secret_access_key = DEFAULTSECRET
+
+[session]
+aws_access_key_id = OLD
+aws_secret_access_key = OLD
+";
+        let updated = update_profile(original, &sample_profile("session"));
+        // Untouched section (and its comments) survive byte-for-byte.
+        assert!(updated.contains(
+            "# top comment\n[default]\naws_access_key_id = DEFAULTKEY\n; keep this comment between keys\naws_secret_access_key = DEFAULTSECRET\n"
+        ));
+        // Target section was rewritten.
+        assert!(updated.contains("[session]\naws_access_key_id = AKIATEST\n"));
+        assert!(!updated.contains("aws_access_key_id = OLD"));
+    }
+
+    #[test]
+    fn test_update_profile_prefix_names_dont_collide() {
+        let original = "\
+[prod]
+aws_access_key_id = PRODKEY
+aws_secret_access_key = PRODSECRET
+
+[production]
+aws_access_key_id = PRODUCTIONKEY
+aws_secret_access_key = PRODUCTIONSECRET
+";
+        let updated = update_profile(original, &sample_profile("prod"));
+        assert!(updated.contains("[prod]\naws_access_key_id = AKIATEST\n"));
+        // [production] must be untouched even though [prod] is a prefix of it.
+        assert!(updated.contains(
+            "[production]\naws_access_key_id = PRODUCTIONKEY\naws_secret_access_key = PRODUCTIONSECRET\n"
+        ));
+        assert!(!updated.contains("PRODKEY"));
+    }
+
+    #[test]
+    fn test_update_profile_comment_mentioning_section_is_not_a_header() {
+        // A comment that merely mentions [session] must not be treated as the
+        // section header (the old `config.contains()` check had this bug).
+        let original = "\
+# remember to rotate [session] keys
+[default]
+aws_access_key_id = DEFAULTKEY
+aws_secret_access_key = DEFAULTSECRET
+";
+        let updated = update_profile(original, &sample_profile("session"));
+        assert!(updated.contains("# remember to rotate [session] keys"));
+        // The profile is appended; the only real `[session]` header is the new one.
+        assert_eq!(updated.matches("[session]\n").count(), 1);
+        assert!(updated.trim_end().ends_with("region = us-east-1"));
+    }
+
+    #[test]
+    fn test_update_profile_dollar_is_literal_not_capture_ref() {
+        // Regression: the previous `Regex::replace` expanded `$1`/`${name}` in the
+        // replacement string, silently dropping characters. Values must be literal.
+        let profile = Profile {
+            name: "session".to_string(),
+            access_key_id: "AKIATEST".to_string(),
+            secret_access_key: "se$1cret".to_string(),
+            session_token: Some("tok${en}".to_string()),
+            region: Some("us-$0-1".to_string()),
+        };
+        let original = "[session]\naws_access_key_id = OLD\naws_secret_access_key = OLD\n";
+        let updated = update_profile(original, &profile);
+        assert!(
+            updated.contains("aws_secret_access_key = se$1cret"),
+            "got:\n{updated}"
+        );
+        assert!(updated.contains("aws_session_token = tok${en}"));
+        assert!(updated.contains("region = us-$0-1"));
+    }
+
+    #[test]
+    fn test_update_profile_replace_last_without_trailing_newline() {
+        let original = "[default]\naws_access_key_id = D\n\n[session]\naws_access_key_id = OLD\naws_secret_access_key = OLD";
+        let updated = update_profile(original, &sample_profile("session"));
+        assert!(updated.contains("[default]\naws_access_key_id = D\n"));
+        assert!(updated.contains("[session]\naws_access_key_id = AKIATEST\n"));
+        assert!(!updated.contains("OLD"));
+        assert!(updated.ends_with("region = us-east-1\n"));
+    }
+
+    #[test]
+    fn test_update_profile_bracket_in_value_does_not_split_section() {
+        // A `[` that is not at the start of a line is not a section boundary, so
+        // the span scan must run past it to the real next header ([session]).
+        let original = "[default]\naws_access_key_id = OLDKEY\nnote = see [archive] dump\naws_secret_access_key = OLDSECRET\n\n[session]\naws_access_key_id = KEEP\n";
+        let updated = update_profile(original, &sample_profile("default"));
+        // [default] replaced wholesale (note line gone); [session] untouched.
+        assert!(!updated.contains("note = see [archive] dump"));
+        assert!(!updated.contains("OLDKEY"));
+        assert!(updated.contains("[default]\naws_access_key_id = AKIATEST\n"));
+        assert!(updated.contains("[session]\naws_access_key_id = KEEP\n"));
+    }
+
+    #[test]
+    fn test_update_profile_handles_crlf_in_untouched_sections() {
+        let original =
+            "[default]\r\naws_access_key_id = D\r\n\r\n[session]\r\naws_access_key_id = OLD\r\n";
+        let updated = update_profile(original, &sample_profile("session"));
+        // CRLF content outside the target is preserved verbatim.
+        assert!(updated.contains("[default]\r\naws_access_key_id = D\r\n"));
+        assert!(updated.contains("[session]\naws_access_key_id = AKIATEST\n"));
+        assert!(!updated.contains("OLD"));
+    }
+
+    #[test]
+    fn test_update_profile_append_then_replace_is_idempotent() {
+        let base = "[default]\naws_access_key_id = D\naws_secret_access_key = S\n";
+        let once = update_profile(base, &sample_profile("session"));
+        let twice = update_profile(&once, &sample_profile("session"));
+        assert_eq!(once, twice);
+        assert!(twice.contains("[default]\naws_access_key_id = D\n"));
+        assert_eq!(twice.matches("[session]\n").count(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_credentials_creates_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // Parent directory does not exist yet either.
+        let path = dir.path().join("nested").join("credentials");
+        assert!(!path.exists());
+
+        unsafe { std::env::set_var(AWS_SHARED_CREDENTIALS_FILE, &path) };
+        let result = update_credentials(&sample_profile("session"));
+        unsafe { std::env::remove_var(AWS_SHARED_CREDENTIALS_FILE) };
+        result.unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("[session]"));
+        assert!(written.contains("aws_access_key_id = AKIATEST"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "newly created credentials file must be 0600"
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_credentials_enforces_0600_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credentials");
+        std::fs::write(&path, "[existing]\naws_access_key_id = OLD\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        unsafe { std::env::set_var(AWS_SHARED_CREDENTIALS_FILE, &path) };
+        let result = update_credentials(&sample_profile("session"));
+        unsafe { std::env::remove_var(AWS_SHARED_CREDENTIALS_FILE) };
+        result.unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("[existing]")); // pre-existing content preserved
+        assert!(written.contains("[session]")); // new profile appended
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "loose 0644 permissions must be tightened to 0600"
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_credentials_does_not_repermission_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        // The parent directory already exists with perms the tool must not change.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path = dir.path().join("credentials");
+
+        unsafe { std::env::set_var(AWS_SHARED_CREDENTIALS_FILE, &path) };
+        let result = update_credentials(&sample_profile("session"));
+        unsafe { std::env::remove_var(AWS_SHARED_CREDENTIALS_FILE) };
+        result.unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir_mode = std::fs::metadata(dir.path()).unwrap().permissions().mode();
+            assert_eq!(
+                dir_mode & 0o777,
+                0o755,
+                "a pre-existing parent directory must be left untouched"
+            );
+            // The credentials file itself is still written 0600.
+            let file_mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(file_mode & 0o777, 0o600);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the following issues in the credentials-file write path (found during an audit):

- **Silent no-write / file corruption in `update_profile`** — regex-based editing replaced with a line-based section replace that touches only the target section and preserves comments/spacing elsewhere. Fixes the no-write on key-less sections, wrong-section over-consume, `[prod]`/`[production]` prefix collisions, comment false-positives, and `$`-expansion corruption from the regex Replacer.
- **World/group-readable credentials** — `update_credentials` now enforces `0600` on the written file instead of inheriting the original file's (possibly loose) permissions.
- **Crash on fresh setup** — a missing credentials file / `~/.aws` directory is now created (and only a directory we create is chmod-ed).

Also drops the now-unused `regex` dependency and corrects two README claims to match the new behavior.

**Tests:** +11 (comment preservation, prefix safety, `$`-literal, CRLF, idempotency, missing-file creation, `0600` enforcement, dir-perms). `cargo test --all` 84+18 green; `fmt` clean; no new clippy warnings.