### PR TITLE
fix(error,args): reject non-ASCII MFA codes; thiserror + drop dead variants

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,10 @@ pub fn region(s: &str) -> Result<Region, CliError> {
 }
 
 fn parse_code(s: &str) -> Result<String, CliError> {
-    if s.chars().all(char::is_numeric) && s.len() == 6 {
+    // ASCII digits only: `char::is_numeric` accepts Unicode digits (e.g. "٦٦٦",
+    // superscripts) and `str::len` counts bytes, so the old check could pass a
+    // non-numeric, non-6-char code. All-ASCII-digit guarantees len == char count.
+    if s.len() == 6 && s.bytes().all(|b| b.is_ascii_digit()) {
         Ok(s.to_string())
     } else {
         Err(CliError::ValidationError(
@@ -103,6 +106,17 @@ mod tests {
         assert!(parse_code("abcdef").is_err());
         assert!(parse_code("12-456").is_err());
         assert!(parse_code("123 56").is_err());
+    }
+
+    #[test]
+    fn test_parse_code_rejects_non_ascii_digits() {
+        // Arabic-Indic digits: 6 chars but 12 bytes, all `char::is_numeric`.
+        assert!(parse_code("٦٦٦٦٦٦").is_err());
+        // Fullwidth digits: 6 chars, 18 bytes.
+        assert!(parse_code("１２３４５６").is_err());
+        // Superscript two (U+00B2): 2 bytes each, so 3 of them is 6 bytes and
+        // `is_numeric` — the case the old `len() == 6` check wrongly accepted.
+        assert!(parse_code("²²²").is_err());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,58 +1,30 @@
 use std::fmt::{Debug, Display};
 
-use aws_sdk_iam::{error::SdkError, operation::list_mfa_devices::ListMFADevicesError};
-use aws_sdk_sts::operation::{
-    get_caller_identity::GetCallerIdentityError, get_session_token::GetSessionTokenError,
-};
+use aws_sdk_iam::error::SdkError;
 use miette::Diagnostic;
+use thiserror::Error;
 
-#[derive(Debug, Diagnostic)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CliError {
+    #[error("Validation error: {0}")]
     ValidationError(String),
+    #[error("No MFA device in user profile")]
     NoMFA,
+    #[error("No returned credentials")]
     NoCredentials,
+    #[error("No returned account")]
     NoAccount,
-    ListMFADevicesError(ListMFADevicesError),
-    GetSessionTokenError(GetSessionTokenError),
-    GetCallerIdentityError(GetCallerIdentityError),
+    #[error("SDKError: {0}")]
     SdkError(String),
-    IoError(std::io::Error),
+    #[error("IOError: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
-impl std::fmt::Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            CliError::ValidationError(e) => write!(f, "Validation error: {e}"),
-            CliError::NoMFA => write!(f, "No MFA device in user profile"),
-            CliError::NoCredentials => write!(f, "No returned credentials"),
-            CliError::NoAccount => write!(f, "No returned account"),
-            CliError::ListMFADevicesError(e) => write!(f, "No mfa devices: {e:?}"),
-            CliError::GetSessionTokenError(e) => write!(f, "Cannot receive token: {e:?}"),
-            CliError::GetCallerIdentityError(e) => write!(f, "Error: {e:?}"),
-            CliError::SdkError(e) => write!(f, "SDKError: {e:?}"),
-            CliError::IoError(e) => write!(f, "IOError: {e:?}"),
-        }
-    }
-}
-
-impl std::error::Error for CliError {}
-
-impl From<std::io::Error> for CliError {
-    fn from(e: std::io::Error) -> Self {
-        CliError::IoError(e)
-    }
-}
-
+// thiserror's `#[from]` only generates `From` for a concrete type, so the
+// generic conversion that collapses every SDK operation error stays manual.
 impl<E: Display + Debug> From<SdkError<E>> for CliError {
     fn from(e: SdkError<E>) -> Self {
-        match e {
-            SdkError::ConstructionFailure(e) => Self::SdkError(format!("{e:?}")),
-            SdkError::TimeoutError(e) => Self::SdkError(format!("{e:?}")),
-            SdkError::DispatchFailure(e) => Self::SdkError(format!("{e:?}")),
-            SdkError::ResponseError(e) => Self::SdkError(format!("{e:?}")),
-            SdkError::ServiceError(e) => Self::SdkError(format!("{e:?}")),
-            _ => Self::SdkError("Unknown SDK error".to_string()),
-        }
+        CliError::SdkError(format!("{e:?}"))
     }
 }
 
@@ -129,7 +101,7 @@ mod tests {
             CliError::NoCredentials,
             CliError::NoAccount,
             CliError::SdkError("SDK error".to_string()),
-            CliError::IoError(std::io::Error::new(std::io::ErrorKind::Other, "test")),
+            CliError::IoError(std::io::Error::other("test")),
         ];
 
         for error in errors {

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,20 @@ mod tests {
     }
 
     #[test]
+    fn test_sdk_error_conversion() {
+        // Any SDK operation error collapses to CliError::SdkError via the generic
+        // From<SdkError<E>>. construction_failure needs no concrete operation error.
+        let sdk_error: SdkError<std::io::Error> =
+            SdkError::construction_failure(std::io::Error::other("boom"));
+        let cli_error: CliError = sdk_error.into();
+
+        match cli_error {
+            CliError::SdkError(msg) => assert!(msg.contains("ConstructionFailure")),
+            _ => panic!("Expected SdkError variant"),
+        }
+    }
+
+    #[test]
     fn test_cli_error_is_error_trait() {
         let error = CliError::ValidationError("test".to_string());
         let _: &dyn Error = &error;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,3 +1,5 @@
+// `PowerShell` is a proper product name, not redundant naming against `Shell`.
+#[allow(clippy::enum_variant_names)]
 #[derive(Default, PartialEq, Debug)]
 pub enum Shell {
     #[default]


### PR DESCRIPTION
This PR fixes the following audit findings (no functional behavior change beyond stricter validation and cleaner error text):

- **`parse_code` accepted non-ASCII "digits"** — `char::is_numeric` + byte-length `len() == 6` let inputs like `٦٦٦٦٦٦` (Arabic-Indic) or `²²²` (6 bytes) pass local validation. Now requires exactly 6 ASCII digits.
- **`CliError` carried 3 never-constructed variants** (`ListMFADevicesError`/`GetSessionTokenError`/`GetCallerIdentityError`) — every SDK error already collapses to `SdkError(String)`. Dropped them, which also clears the `clippy::result_large_err` warnings they caused.
- **Hand-rolled `Display`/`Error`/`From`** replaced with `#[derive(thiserror::Error, Diagnostic)]`. The previous empty `impl Error {}` broke `source()` chaining; `#[from]` on `IoError` restores it. The generic `From<SdkError<E>>` stays manual (thiserror can't derive it) and is collapsed to a single arm.

Note: `SdkError`/`IoError` now render via `Display` instead of `Debug`, so their error messages are cleaner (e.g. `IOError: No such file or directory (os error 2)`). The four pinned `Display` strings (validation/no-MFA/no-credentials/no-account) are unchanged.

Also clears the last two clippy nits (`io_other_error` in a test; `enum_variant_names` on the `PowerShell` variant via a documented `#[allow]`).

**Tests:** +1 (`parse_code` non-ASCII rejection); existing error-display/source tests still pass. `cargo test --all` 85+18 green; `fmt` clean; **`cargo clippy` now warning-free**.