### PR TITLE
ci: add cargo-audit security gate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+# cargo-audit configuration — https://docs.rs/cargo-audit
+#
+# The advisories below are ignored because there is no available fix on our
+# dependency path. They all originate from rustls-webpki 0.101.7, which is
+# pulled in transitively via aws-smithy-http-client 1.1.13 (the latest
+# published version) -> hyper-rustls 0.24.2 -> rustls 0.21.12. `cargo update`
+# is a no-op for this chain and no newer aws-smithy-http-client drops the old
+# rustls 0.21 stack, so the fix has to land upstream in the AWS Smithy runtime.
+#
+# Re-evaluate (and remove entries that no longer appear) whenever the
+# aws-config / aws-sdk-* dependencies are bumped.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0098", # rustls-webpki: name constraints for URI names incorrectly accepted
+    "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certificates
+    "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Security audit
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    # Daily, so newly disclosed advisories on unchanged dependencies are caught.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: cargo audit
+        # Ignored advisories live in .cargo/audit.toml (auto-discovered).
+        run: cargo audit


### PR DESCRIPTION
This PR fixes: no supply-chain vulnerability scanning in CI (audit finding #3).

## What

- Adds `.github/workflows/audit.yml` — runs `cargo audit` on push to `master`, on PRs, daily via `schedule` (catches newly disclosed advisories on unchanged deps), and via `workflow_dispatch`. Least-privilege `permissions: contents: read`.
- Adds `.cargo/audit.toml` with a documented ignore list for the 3 currently-unfixable advisories.

## The ignored advisories

`RUSTSEC-2026-0098`, `-0099`, `-0104` all originate from `rustls-webpki 0.101.7`, pulled transitively via `aws-smithy-http-client 1.1.13` (latest) → `hyper-rustls 0.24.2` → `rustls 0.21.12`. `cargo update` is a no-op for this chain and no newer `aws-smithy-http-client` drops the old rustls 0.21 stack, so the fix has to land upstream. The rationale is recorded inline; re-evaluate when `aws-config`/`aws-sdk-*` are bumped.

## Verification

The gate is meaningful, not always-green — verified locally:
- all 3 ignored → exit 0
- any one removed from the ignore list → exit 1