### PR TITLE
ci: harden workflows and declare MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,6 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: tokio
-    versions:
-    - 1.1.1
-    - 1.2.0
-    - 1.3.0
-    - 1.4.0
-  - dependency-name: regex
-    versions:
-    - 1.4.3
-    - 1.4.4
-    - 1.4.5
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,9 +2,16 @@ name: Code check
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
+    # clippy-action posts results as a check run via the github-pr-check reporter.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo
@@ -19,9 +26,8 @@ jobs:
             target
           key: clippy-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install clippy
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
       - name: clippy check
         uses: giraffate/clippy-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -22,9 +25,10 @@ jobs:
           ~/.cargo/git
           target
         key: coverage-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - uses: cargo-bins/cargo-binstall@main
     - name: Install cargo-tarpaulin
-      run: cargo binstall cargo-tarpaulin
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-tarpaulin
     - name: Run coverage
       run: cargo tarpaulin -f -t 5 --out Xml -v -- --test-threads=1 || true
     - name: Upload coverage to Codecov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
       - "*"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on:  ${{ matrix.os }}
@@ -34,3 +37,25 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: trace
+
+  msrv:
+    # Verifies the rust-version declared in Cargo.toml still builds, and flags
+    # drift when an AWS SDK dependency raises its MSRV.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/git
+            target
+          key: msrv-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install MSRV toolchain (1.91.1)
+        uses: dtolnay/rust-toolchain@1.91.1
+      - name: cargo check on MSRV
+        run: cargo check --locked --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ keywords = ["aws", "sts", "token", "credentials"]
 categories = ["command-line-utilities"]
 exclude = [".github/*"]
 edition = "2024"
+# Minimum supported Rust version. The floor is driven by the aws-config /
+# aws-sdk-* family, which currently declare rust-version = 1.91.1 (well above the
+# edition-2024 minimum of 1.85). Bump when those dependencies raise their MSRV;
+# the `msrv` CI job verifies this value still builds.
+rust-version = "1.91.1"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
This PR fixes: missing least-privilege permissions, mutable action refs, stale dependabot config, and no declared MSRV (audit findings in the CI/supply-chain bucket).

## What

**Least-privilege permissions** — add `permissions:` blocks to the Rust, Code check and Coverage workflows. Default is `contents: read`; the clippy job additionally gets `checks: write` (required by `giraffate/clippy-action`'s `github-pr-check` reporter). Coverage uses `CODECOV_TOKEN` (not OIDC), so `contents: read` is sufficient there.

**Pin mutable action refs**
- `clippy.yml`: `dtolnay/rust-toolchain@master` → `@stable` (matches the `fmt` job; drops the redundant `toolchain: stable` input).
- `coverage.yml`: replace `cargo-bins/cargo-binstall@main` with `taiki-e/install-action@v2` (versioned) to install `cargo-tarpaulin`.

**Dependabot cleanup** — remove stale `ignore` entries: `regex` (the dependency was removed in #284) and the long-obsolete `tokio` 1.1–1.4 pins.

**MSRV** — declare `rust-version = "1.91.1"` in `Cargo.toml`. This is the *verified* floor, driven by the `aws-config`/`aws-sdk-*` family (all declare `rust-version = 1.91.1`, well above the edition-2024 minimum of 1.85). A new `msrv` CI job builds on the 1.91.1 toolchain so the number stays honest and drift is caught when an SDK bump raises it.

## Verification

- `cargo +1.91.1 check --locked --all-targets` passes locally (the `msrv` job mirrors this).
- `actionlint` clean on all three changed workflows.

## Not included (deliberately)
- The hard `clippy -D warnings` gate — depends on #285 (pre-existing latent warnings on master); will follow once #285 merges.
- `release.yml` hardening — tag-only and untestable in a PR; deserves its own change for conscious review.