### PR TITLE
ci: make clippy a hard gate with -D warnings

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,10 @@
 name: Code check
 
-on: [ pull_request ]
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
 
 permissions:
   contents: read
@@ -8,10 +12,6 @@ permissions:
 jobs:
   clippy:
     runs-on: ubuntu-latest
-    # clippy-action posts results as a check run via the github-pr-check reporter.
-    permissions:
-      contents: read
-      checks: write
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo
@@ -30,10 +30,7 @@ jobs:
         with:
           components: clippy
       - name: clippy check
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy --all-targets --all-features -- -D warnings
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR fixes: clippy warnings only annotated PRs instead of failing CI, and clippy never ran on pushes to master (audit finding in the CI bucket).

## What

- Replace the non-blocking `giraffate/clippy-action` (github-pr-check reporter) with a direct **`cargo clippy --all-targets --all-features -- -D warnings`** step, so any lint warning fails the job.
- Run on `push` (matching the Rust workflow) in addition to `pull_request`, so master is gated too.
- Drop the clippy job's `checks: write` permission — it was only needed by the annotation reporter; the job now inherits top-level `contents: read`.

## Why now

This was deliberately held back until **#285** merged: master previously had latent warnings (`enum_variant_names` on `Shell::PowerShell`, `io_other_error` in `error.rs`) that #285 removed. Verified locally that `cargo clippy --all-targets --all-features -- -D warnings` is now clean on master, so this gate goes green rather than red on landing.