### PR TITLE
ci: harden the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,25 +5,52 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
-  release-crates:
+  # Gate: never publish or attach artifacts for a tag whose tests don't pass.
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: publish package to crates
+      - uses: dtolnay/rust-toolchain@stable
+      - name: test
+        run: cargo test --locked --all --verbose
+
+  release-crates:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: publish to crates.io
+        # Skip if this version is already published so re-running a release is
+        # idempotent, but let any real publish failure fail the job (the old
+        # `|| true` masked every error, including broken packaging).
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: |
-          cargo package
-          cargo publish --token ${{ secrets.CARGO_TOKEN }} || true
+          version="${GITHUB_REF_NAME#v}"
+          if curl -fsSL -A "aws-mfa-session-release-ci" \
+            "https://crates.io/api/v1/crates/aws-mfa-session/${version}" -o /dev/null; then
+            echo "aws-mfa-session ${version} is already on crates.io; skipping publish."
+          else
+            cargo publish --locked --token "${CARGO_TOKEN}"
+          fi
 
   release-linux:
+    needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: static build release
         run: |
           docker run --rm -t \
             -v "$(pwd)":/volume \
-            clux/muslrust cargo build --release
+            clux/muslrust cargo build --release --locked
       - name: archive
         run: |
           sudo strip target/x86_64-unknown-linux-musl/release/aws-mfa-session
@@ -36,14 +63,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-linux-arm:
+    needs: test
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: static build release
         run: |
           docker run --rm -t \
             -v "$(pwd)":/volume \
-            clux/muslrust cargo build --release
+            clux/muslrust cargo build --release --locked
       - name: archive
         run: |
           sudo strip target/aarch64-unknown-linux-musl/release/aws-mfa-session
@@ -56,12 +86,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-osx:
+    needs: test
     runs-on: macOS-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: build release
-        run: cargo build --release --verbose
+        run: cargo build --release --locked --verbose
       - name: archive
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-aarch64-osx.tar.gz aws-mfa-session
       - name: publish release
@@ -72,12 +105,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-osx-x86_64:
+    needs: test
     runs-on: macos-15-intel
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: build release
-        run: cargo build --release --verbose
+        run: cargo build --release --locked --verbose
       - name: archive
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-x86_64-osx.tar.gz aws-mfa-session
       - name: publish release
@@ -88,11 +124,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-windows:
+    needs: test
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: build release
-        run: cargo build --release --verbose
+        run: cargo build --release --locked --verbose
       - name: archive
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-x86_64-windows.tar.gz aws-mfa-session.exe
         shell: bash
@@ -104,12 +143,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-windows-arm:
+    needs: test
     runs-on: windows-11-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: build release
-        run: cargo build --release --verbose
+        run: cargo build --release --locked --verbose
       - name: archive
         run: tar -C target/release -czf $(pwd)/aws-mfa-session-aarch64-windows.tar.gz aws-mfa-session.exe
         shell: bash


### PR DESCRIPTION
This PR fixes: the release pipeline could publish/attach artifacts for a failing tag, masked publish errors with `|| true`, didn't build from the locked dependency set, and ran with broad default permissions (audit findings in the release bucket).

> ⚠️ The release workflow runs **only on tag pushes**, so none of this can be exercised in a PR. Flagging for conscious review — the changes are validated by reasoning + a local check of the one piece of real logic (below), not by CI.

## Changes

- **Test gate** — new `test` job (`cargo test --locked --all`) that every release job depends on via `needs:`. A tag whose tests fail never publishes to crates.io or uploads binaries. Runs on `ubuntu-latest`, which sidesteps the Windows-only persist flake.
- **`--locked` builds** — musl docker builds and native osx/windows builds all use `--locked`, so releases come from the committed `Cargo.lock`.
- **Least-privilege permissions** — default `contents: read`; only the six artifact-upload jobs get `contents: write`. The crates.io job uses `CARGO_TOKEN` (not `GITHUB_TOKEN`), so it needs no write.
- **Idempotent publish** — replace `cargo publish … || true` (which swallowed *every* error, including broken packaging) with a skip-if-already-published guard: query the crates.io API for this tag's version, skip only if it already exists, otherwise publish and let real failures fail the job.

## What I verified locally
The skip-if-published logic, against the real crates.io API:
- `0.4.3` (published) → curl 200 → **skips** ✓
- `99.99.99` (unpublished) → curl 404 → **publishes** ✓

`actionlint` is clean apart from **pre-existing** `SC2046` warnings on the archive `$(pwd)` usage — left byte-for-byte unchanged to avoid altering the known-working, untestable archive steps.

Branched off `master`; independent of the other open PRs.