### PR TITLE
fix: batch B correctness fixes

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -57,6 +57,20 @@ pub struct Args {
 }
 
 impl Args {
+    /// At least one output mode must be selected. Otherwise `run` would mint a
+    /// session token — spending the single-use MFA code — and then discard it.
+    pub fn ensure_output_mode(&self) -> Result<(), CliError> {
+        if self.shell || self.export || self.session_profile.is_some() {
+            Ok(())
+        } else {
+            Err(CliError::ValidationError(
+                "no output mode selected: pass at least one of --shell/-s, \
+                 --export/-e, or --update-profile/-u"
+                    .to_string(),
+            ))
+        }
+    }
+
     pub fn get_code(&mut self) -> Result<(), CliError> {
         self.code = match &self.code {
             None => {
@@ -117,6 +131,25 @@ mod tests {
         // Superscript two (U+00B2): 2 bytes each, so 3 of them is 6 bytes and
         // `is_numeric` — the case the old `len() == 6` check wrongly accepted.
         assert!(parse_code("²²²").is_err());
+    }
+
+    #[test]
+    fn test_ensure_output_mode_rejects_when_none_selected() {
+        let args = Args::try_parse_from(["aws-mfa-session", "-c", "123456"]).unwrap();
+        assert!(args.ensure_output_mode().is_err());
+    }
+
+    #[test]
+    fn test_ensure_output_mode_accepts_each_mode() {
+        for flag in ["-s", "-e"] {
+            let args = Args::try_parse_from(["aws-mfa-session", "-c", "123456", flag]).unwrap();
+            assert!(
+                args.ensure_output_mode().is_ok(),
+                "{flag} should be accepted"
+            );
+        }
+        let args = Args::try_parse_from(["aws-mfa-session", "-c", "123456", "-u", "sess"]).unwrap();
+        assert!(args.ensure_output_mode().is_ok());
     }
 
     #[test]

--- a/src/bin/aws-mfa-session.rs
+++ b/src/bin/aws-mfa-session.rs
@@ -13,9 +13,8 @@ async fn main() {
     fmt().with_env_filter(filter).init();
 
     if let Err(e) = opts.get_code() {
-        eprintln!("Error: {e}");
         tracing::error!(?e, "application error");
-        // Print a fancy error report using miette
+        // Report the error once, as a fancy miette diagnostic.
         eprintln!("{}", miette::Report::new(e));
         exit(1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,15 @@ const AWS_DEFAULT_REGION: &str = "AWS_DEFAULT_REGION";
 const AWS_SHARED_CREDENTIALS_FILE: &str = "AWS_SHARED_CREDENTIALS_FILE";
 
 pub async fn run(opts: Args) -> Result<(), CliError> {
+    // Validate inputs before touching AWS — and before the single-use MFA code
+    // is spent on a session token. Bail if there is no output mode to consume
+    // the credentials, or if no MFA code is available (a library caller may not
+    // have run get_code()); the latter previously panicked via `.expect`.
+    opts.ensure_output_mode()?;
+    let token_code = opts
+        .code
+        .ok_or_else(|| CliError::ValidationError("MFA code is required".to_string()))?;
+
     // ProfileProvider is limited, but AWS_PROFILE is used elsewhere
     if let Some(ref profile) = opts.profile {
         // SAFETY: Setting AWS_PROFILE environment variable is safe in this single-threaded context
@@ -83,10 +92,7 @@ pub async fn run(opts: Args) -> Result<(), CliError> {
     let credentials = sts_client
         .get_session_token()
         .set_serial_number(Some(serial_number))
-        .token_code(
-            opts.code
-                .expect("MFA code should be available after get_code() call"),
-        )
+        .token_code(token_code)
         .duration_seconds(opts.duration)
         .send()
         .await?
@@ -115,7 +121,10 @@ pub async fn run(opts: Args) -> Result<(), CliError> {
             access_key_id: c.access_key_id().to_owned(),
             secret_access_key: c.secret_access_key().to_owned(),
             session_token: Some(c.session_token().to_owned()),
-            region: opts.region.map(|r| r.to_string()),
+            // Record the region the session was actually minted under (resolved
+            // from --region, env, profile, or the default) so the written
+            // profile is self-contained, not only when --region was passed.
+            region: shared_config.region().map(|r| r.to_string()),
         };
         update_credentials(&profile)?;
     }
@@ -151,6 +160,25 @@ pub async fn run(opts: Args) -> Result<(), CliError> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[tokio::test]
+    async fn test_run_rejects_missing_output_mode() {
+        // With no -s/-e/-u, run must return an error before any AWS work, so the
+        // MFA code is never sent to STS (guard is the first statement in run).
+        let opts = Args::try_parse_from(["aws-mfa-session", "--code", "123456"]).unwrap();
+        assert!(matches!(run(opts).await, Err(CliError::ValidationError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_run_rejects_missing_code() {
+        // Output mode selected but no MFA code (e.g. a library caller that never
+        // ran get_code): run must return an error, not panic, before any AWS work.
+        let opts = Args::try_parse_from(["aws-mfa-session", "--export"]).unwrap();
+        assert_eq!(opts.code, None);
+        assert!(matches!(run(opts).await, Err(CliError::ValidationError(_))));
+    }
 
     #[test]
     fn test_env_var_setting_logic() {


### PR DESCRIPTION
This PR fixes: four correctness issues from the audit (batch B).

## Fixes

1. **Burning an MFA code on a no-op run.** With no output mode (`-s/-e/-u`), `run` would still call STS `get_session_token` — spending the single-use MFA code — and then discard the credentials. New `Args::ensure_output_mode()` is checked first in `run`, before any AWS call, so nothing is minted. (Unit-tested + a `run` early-return test.)

2. **`.expect()` panic on the MFA code.** `opts.code.expect(...)` panicked for a library caller that constructs `Args` directly and never runs `get_code()`. Replaced with a validated `CliError::ValidationError`, moved ahead of any AWS work (fail-fast, and now testable).

3. **Session profile missing its region.** `-u/--update-profile` only wrote a `region` line when `--region` was passed. It now records the region the session was actually minted under (`shared_config.region()`), so the written profile is self-contained.

4. **Duplicate error print.** On the interactive (`get_code`) path the binary printed both a plain `Error: …` line and the miette report. Now it reports once.

## ⚠️ Behavior change (for conscious review)
Fix 3 means `-u/--update-profile` now always records a region — the resolved one (e.g. `us-east-1`) even when nothing is explicitly configured. Previously the profile had no region unless `--region` was given.

## Deliberately dropped from batch B
- **Fish `$` / Cmd `%` export escaping** — pure defense-in-depth: AWS creds are base64 (`A-Za-z0-9+/=`), IAM usernames can't contain `$`/`%`, and the PS1 prompt already carries a pre-escaped `\$`. Never triggers; a "proper" $-escaper would actually re-mangle that `\$`.
- **`Shell::from` basename rewrite** — would break 4 tests that intentionally lock in the current `ends_with` + case-sensitivity semantics, for ~zero real gain (the only gap is bare non-bash names like `SHELL=zsh`). A safe *additive* fix (exact-match arms for bare `zsh`/`fish`/`sh`) is available on request.

## Notes
- Fix 4 is intentionally minimal (drop the redundant line) rather than a full rewrite of `main`'s error handling, to keep `main` (untestable) out of the codecov/patch surface.
- `cargo clippy --all-targets --all-features -- -D warnings`, `fmt`, and all tests pass locally.

Branched off current `master`; disjoint from the still-open #288.